### PR TITLE
Changing default image ml-dev-2.0

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,7 @@
     "open_source_license": "Not open source",
     "author_name": "",
     "description": "My Project Description",
-    "base_docker_image": "manifoldai/orbyter-ml-dev:1.8",
+    "base_docker_image": "manifoldai/orbyter-ml-dev:2.0",
     "mlflow_uri": "/mnt/experiments",
     "mlflow_artifact": ""
 }


### PR DESCRIPTION
# Context

Changing CC to default to latest Orbyter image.

# Changes

* cookiecutter.json default

# Behaves Differently

* oob CC scaffolded repos will use Orbyter 2.0.

# Untested

* Need to test image works. Will do so. 
